### PR TITLE
feat: expose styling and props for all internal components via props

### DIFF
--- a/src/components/Backdrop/Backdrop.js
+++ b/src/components/Backdrop/Backdrop.js
@@ -3,7 +3,12 @@ import "./Backdrop.css";
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
 
-const Backdrop = ({ children, onClickAway, backgroundColor="rgba(1,1,1,0.5)" }) => {
+const Backdrop = ({
+  children,
+  onClickAway,
+  backgroundColor = "rgba(1,1,1,0.5)",
+  style,
+}) => {
   const id = uuidv4();
 
   const onClickHandler = (event) => {
@@ -12,12 +17,15 @@ const Backdrop = ({ children, onClickAway, backgroundColor="rgba(1,1,1,0.5)" }) 
     }
   };
 
-  const style = {
-    backgroundColor,
-  };
-
   return (
-    <div style={style} className={`${id} Backdrop`} onClick={onClickHandler}>
+    <div
+      style={{
+        backgroundColor,
+        ...style,
+      }}
+      className={`${id} Backdrop`}
+      onClick={onClickHandler}
+    >
       {children}
     </div>
   );

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -2,8 +2,12 @@ import "./Box.css";
 
 import React from "react";
 
-const Box = ({ children, elevated }) => {
-  return <div className={`Box ${elevated && "elevated"}`}>{children}</div>;
+const Box = ({ children, elevated, style }) => {
+  return (
+    <div style={style} className={`Box ${elevated && "elevated"}`}>
+      {children}
+    </div>
+  );
 };
 
 export default Box;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,7 +2,16 @@ import "./Button.css";
 
 import React from "react";
 
-const Button = ({ label, active, fill, size, color, elevated, onClick }) => {
+const Button = ({
+  label,
+  active,
+  fill,
+  size,
+  color,
+  elevated,
+  onClick,
+  style,
+}) => {
   return (
     <button
       onClick={onClick}
@@ -11,6 +20,7 @@ const Button = ({ label, active, fill, size, color, elevated, onClick }) => {
       } ${color} ${
         active ? (fill ? `active fill` : `active no-fill`) : `disabled`
       }`}
+      style={style}
     >
       {label}
     </button>

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -2,13 +2,13 @@ import "./ButtonGroup.css";
 
 import React from "react";
 
-const ButtonGroup = ({ children, vertical }) => {
+const ButtonGroup = ({ children, vertical, style }) => {
   if (children == null) return <div></div>;
 
   if (children.length == 1) return children[0];
 
   return (
-    <div className={`ButtonGroup ${vertical && "vertical"}`}>{children}</div>
+    <div style={style} className={`ButtonGroup ${vertical && "vertical"}`}>{children}</div>
   );
 };
 

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -2,8 +2,8 @@ import "./Checkbox.css";
 
 import React from "react";
 
-const Checkbox = ({ checked = false }) => {
-  return <input type="checkbox"></input>;
+const Checkbox = ({ checked = false, style }) => {
+  return <input style={style} type="checkbox"></input>;
 };
 
 export default Checkbox;

--- a/src/components/ClickawayListener/ClickawayListener.js
+++ b/src/components/ClickawayListener/ClickawayListener.js
@@ -3,7 +3,12 @@ import "./ClickawayListener.css";
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
 
-const ClickawayListener = ({ children, onClickAway, backgroundColor }) => {
+const ClickawayListener = ({
+  children,
+  onClickAway,
+  backgroundColor,
+  style,
+}) => {
   const id = uuidv4();
 
   const onClickHandler = (event) => {
@@ -12,12 +17,15 @@ const ClickawayListener = ({ children, onClickAway, backgroundColor }) => {
     }
   };
 
-  const style = {
-    backgroundColor,
-  }
-
   return (
-    <div style={style} className={`${id} ClickawayListener`} onClick={onClickHandler}>
+    <div
+      style={{
+        backgroundColor,
+        ...style,
+      }}
+      className={`${id} ClickawayListener`}
+      onClick={onClickHandler}
+    >
       {children}
     </div>
   );

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -1,8 +1,6 @@
 import React from "react";
-
+import { Backdrop, Box, Container, Hidden } from "../index";
 import "./Dialog.css";
-
-import { Container, Hidden, Backdrop, Box } from "../index";
 
 const Dialog = ({
   isOpen = false,
@@ -10,17 +8,25 @@ const Dialog = ({
   children,
   width = "50%",
   height = "initial",
+  containerComponentProps,
+  hiddenComponentProps,
+  backdropComponentProps,
+  dialogMessageContainerProps,
+  dialogMessageBoxProps,
 }) => {
   return (
-    <Container>
-      <Hidden hidden={!isOpen}>
+    <Container {...containerComponentProps}>
+      <Hidden hidden={!isOpen} {...hiddenComponentProps}>
         <Backdrop
+          {...backdropComponentProps}
           onClickAway={() => {
             onClose();
           }}
         >
-          <Container style={{ width, height }}>
-            <Box elevated>{children}</Box>
+          <Container {...dialogMessageContainerProps} style={{ width, height }}>
+            <Box {...dialogMessageBoxProps} elevated>
+              {children}
+            </Box>
           </Container>
         </Backdrop>
       </Hidden>

--- a/src/components/Divider/Divider.js
+++ b/src/components/Divider/Divider.js
@@ -2,7 +2,7 @@ import "./Divider.css";
 
 import React from "react";
 
-const Divider = ({ color, vertical, height, width, margin }) => {
+const Divider = ({ color, vertical, height, width, margin, style }) => {
   if (vertical) {
     return (
       <div
@@ -11,6 +11,7 @@ const Divider = ({ color, vertical, height, width, margin }) => {
           height,
           color,
           margin,
+          ...style,
         }}
       />
     );
@@ -22,6 +23,7 @@ const Divider = ({ color, vertical, height, width, margin }) => {
         width,
         color,
         margin,
+        ...style,
       }}
       className="Divider"
     />

--- a/src/components/Drawer/Drawer.js
+++ b/src/components/Drawer/Drawer.js
@@ -13,13 +13,19 @@ const Drawer = ({
   onClose,
   size = "20%",
   backgroundColor,
+  style,
+  hiddenComponentProps,
+  clickawayListenerComponentProps,
+  drawerContentContainerProps,
+  drawerContainerProps,
 }) => {
   const onCloseHandler = () => {
     onClose();
   };
 
-  let style = {
+  style = {
     backgroundColor,
+    ...style,
   };
 
   if (position === "left" || position === "right") {
@@ -29,13 +35,22 @@ const Drawer = ({
   }
 
   return (
-    <Hidden hidden={!isOpen}>
-      <ClickawayListener onClickAway={onCloseHandler}>
+    <Hidden {...hiddenComponentProps} hidden={!isOpen}>
+      <ClickawayListener
+        {...clickawayListenerComponentProps}
+        onClickAway={onCloseHandler}
+      >
         <Container
+          {...drawerContainerProps}
           style={style}
           classes={[`Drawer ${position} ${isOpen && "isOpen"}`]}
         >
-          <Container classes={[`DrawerContainer`]}>{children}</Container>
+          <Container
+            {...drawerContentContainerProps}
+            classes={[`DrawerContainer`]}
+          >
+            {children}
+          </Container>
         </Container>
       </ClickawayListener>
     </Hidden>

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,14 +1,10 @@
+import React from "react";
 import "./Link.css";
 
-import React from "react";
-
-const Link = ({ href, label, color, size }) => {
-  const style = { color, fontSize: size };
-  return (
-    <a className={`Link`} href={href} style={style}>
-      {label}
-    </a>
-  );
-};
+const Link = ({ href, label, color, size: fontSize, style }) => (
+  <a className={`Link`} href={href} style={{ color, fontSize, ...style }}>
+    {label}
+  </a>
+);
 
 export default Link;

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,6 +1,5 @@
-import "./List.css";
-
 import React from "react";
+import "./List.css";
 
 const List = ({ children, ordered, plain, dense }) => {
   const classes = `List ${plain && "plain"} ${dense && "dense"}`;

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -1,8 +1,6 @@
-import "./ListItem.css";
-
 import React from "react";
-
 import Button from "../Button";
+import "./ListItem.css";
 
 const ListItem = ({
   alignItems,
@@ -16,6 +14,10 @@ const ListItem = ({
   dense,
   disabled,
   divider,
+  leftIconContainerProps,
+  labelContainerProps,
+  secondaryTextContainerProps,
+  rightIconContainerProps,
 }) => {
   const style = {
     alignItems,
@@ -29,10 +31,18 @@ const ListItem = ({
     );
   return (
     <li className="ListItem" style={style}>
-      <div className="ListItemLeftIcon">{leftIcon}</div>
-      <div className="ListItemLabel">{label}</div>
-      <div className="ListItemSecondaryText">{secondaryText}</div>
-      <div className="ListItemRightIcon">{rightIcon}</div>
+      <div className="ListItemLeftIcon" {...leftIconContainerProps}>
+        {leftIcon}
+      </div>
+      <div className="ListItemLabel" {...labelContainerProps}>
+        {label}
+      </div>
+      <div className="ListItemSecondaryText" {...secondaryTextContainerProps}>
+        {secondaryText}
+      </div>
+      <div className="ListItemRightIcon" {...rightIconContainerProps}>
+        {rightIcon}
+      </div>
       {children}
     </li>
   );

--- a/src/components/RadioList/RadioList.js
+++ b/src/components/RadioList/RadioList.js
@@ -1,15 +1,17 @@
-import "./RadioList.css";
-
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
+import "./RadioList.css";
 
-const RadioList = ({ data, onSelect, horizontal }) => {
+const RadioList = ({ data, onSelect, horizontal, containerComponentProps }) => {
   if (data == null) return <div></div>;
 
   const name = uuidv4();
 
   return (
-    <div className={`RadioList ${horizontal && "horizontal"}`}>
+    <div
+      {...containerComponentProps}
+      className={`RadioList ${horizontal && "horizontal"}`}
+    >
       {data.map(({ label, value }) => {
         const id = uuidv4();
         return (

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -1,13 +1,18 @@
+import React from "react";
+import Container from "../Container";
 import "./Switch.css";
 
-import React from "react";
-
-import Container from "../Container";
-
-const Switch = ({ size, checked, onClick, label }) => {
-  const onToggle = (event) => {
-    onClick(event.target.checked);
-  };
+const Switch = ({
+  size,
+  checked,
+  onClick,
+  label,
+  containerComponentProps,
+  labelComponentProps,
+  inputComponentProps,
+  sliderComponentProps,
+}) => {
+  const onToggle = (event) => onClick(event.target.checked);
 
   return (
     <Container
@@ -15,6 +20,7 @@ const Switch = ({ size, checked, onClick, label }) => {
       style={{
         alignItems: "center",
       }}
+      {...containerComponentProps}
     >
       <label className={`Switch ${size || "large"}`}>
         <input
@@ -22,10 +28,15 @@ const Switch = ({ size, checked, onClick, label }) => {
           onClick={onToggle}
           className="SwitchInput"
           type="checkbox"
+          {...inputComponentProps}
         />{" "}
-        <span className="Switch-slider Switch-round"></span>
+        <span
+          {...sliderComponentProps}
+          className="Switch-slider Switch-round"
+        ></span>
       </label>
       <p
+        {...labelComponentProps}
         style={{
           paddingLeft: "10px",
         }}

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -1,6 +1,5 @@
-import "./Text.css";
-
 import React from "react";
+import "./Text.css";
 
 const Text = ({
   children,
@@ -13,8 +12,9 @@ const Text = ({
   textWrap,
   paragraph,
   classes = [],
+  style,
 }) => {
-  const style = {
+  style = {
     fontWeight: weight,
     fontSize: `${size}px`,
     textAlign: align,
@@ -22,6 +22,7 @@ const Text = ({
     display,
     textWrap,
     marginBottom: paragraph ? "10px" : "",
+    ...style,
   };
 
   classes.push("Text");

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -15,10 +15,11 @@ const TextField = ({
   padding,
   margin,
   height,
+  style,
 }) => {
   const [text, setText] = React.useState(value);
 
-  const style = {
+  style = {
     fontSize,
     color,
     background,
@@ -26,6 +27,7 @@ const TextField = ({
     padding,
     margin,
     height,
+    ...style,
   };
 
   const onValueChange = (e) => {


### PR DESCRIPTION
Limited customisability  is the worst thing about working with component libraries, the whole point of nonagon is to build my perfect component library, and one of the most important things is to expose literally everything to nonagon users.

There's nothing more annoying  than having to use a default DOM element because the library you're using doesn't expose that one prop that you need and you can't install another component library because who does that. The purpose and intent of this PR is to solve that, by exposing the props of the internal components that make up each component. While for now it will require some digging into the source code to better understand what the prop is actually messing with, this will change once we have public docs setup.